### PR TITLE
Use new projectred_4_7 assets

### DIFF
--- a/packs/beyondreality.json
+++ b/packs/beyondreality.json
@@ -75,7 +75,7 @@
     "powersuits",
     "pressure",
     "ProjectBlue",
-    "ProjectRed",
+    "projectred_4_7",
     "Railcraft",
     "RandomThings",
     "RouterReborn",


### PR DESCRIPTION
There are new proper assets for BR ProjectRed: https://github.com/Soartex-Modded/Modded-1.7.x/commit/5baab6d03bbb77cdecf01c8e1d01adb5675d0936#diff-2ee4d20f63f0aeca4e8a5127524145c0

Beyond Reality use these updated Project Red assets:
```
ProjectRed-1.7.10-4.6.2.82-Base.jar
ProjectRed-1.7.10-4.6.2.82-Compat.jar
ProjectRed-1.7.10-4.6.2.82-Integration.jar
ProjectRed-1.7.10-4.6.2.82-Lighting.jar
ProjectRed-1.7.10-4.6.2.82-World.jar
```