### PR TITLE
fix(gt-new-horizons): modid of storagedrawers

### DIFF
--- a/packs/technic/gt_new_horizons.json
+++ b/packs/technic/gt_new_horizons.json
@@ -60,7 +60,7 @@
     "bq_standard",
     "BrandonsCore",
     "bt",
-    "BuildCraft_7",
+    "Binnies_Mods",
     "BuildCraftOilTweak",
     "CarpentersBlocks",
     "catwalks",

--- a/packs/technic/gt_new_horizons.json
+++ b/packs/technic/gt_new_horizons.json
@@ -60,7 +60,7 @@
     "bq_standard",
     "BrandonsCore",
     "bt",
-    "Binnies_Mods",
+    "BuildCraft_7",
     "BuildCraftOilTweak",
     "CarpentersBlocks",
     "catwalks",

--- a/packs/technic/gt_new_horizons.json
+++ b/packs/technic/gt_new_horizons.json
@@ -53,7 +53,7 @@
     "BiblioWoodsBoP",
     "BiblioWoodsForestry",
     "BiblioWoodsNatura",
-    "BinnieCore",
+    "Binnies_Mods",
     "BiomesOPlenty",
     "blocklimiter",
     "BloodArsenal",

--- a/packs/technic/gt_new_horizons.json
+++ b/packs/technic/gt_new_horizons.json
@@ -172,7 +172,7 @@
     "StevesAddons",
     "StevesCarts",
     "StevesFactoryManager",
-    "StorageDrawers",
+    "storagedrawers",
     "StorageDrawersBiomesOPlenty",
     "StorageDrawersForestry",
     "StorageDrawersMisc",


### PR DESCRIPTION
Soartex's Mod ID is `storagedrawers` ← all lowercase
Whereas `StorageDrawers-1.7.10...jar`'s Mod ID is `StorageDrawers` ← CamelCase
